### PR TITLE
create Headers type that will safely and conviently deal with duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package provides types and helper functions for dealing with the HTTP proto
 ## Documentation
 ### Request
 
-A `Request` represents an HTTP request sent by a client to a server. 
+A `Request` represents an HTTP request sent by a client to a server.
 
     :::julia
     type Request
@@ -31,7 +31,7 @@ A `Request` represents an HTTP request sent by a client to a server.
 
 * `method` is an HTTP methods string ("GET", "PUT", etc)
 * `resource` is the url resource requested ("/hello/world")
-* `headers` is a `Dict` of field name `String`s to value `String`s
+* `headers` is an `Associative` of field name `String`s to value `String`s
 * `data` is the data in the request
 
 ### Response
@@ -47,7 +47,7 @@ A `Response` represents an HTTP response sent to a client by a server.
     end
 
 * `status` is the HTTP status code (see `STATUS_CODES`) [default: `200`]
-* `headers` is the `Dict` of headers [default: `headers()`, see Headers below]
+* `headers` is the headers [default: `headers()`, see Headers below]
 * `data` is the response data (as a `String` or `Array{Uint8}`) [default: `""`]
 * `finished` is `true` if the `Reponse` is valid, meaning that it can be converted to an actual HTTP response [default: `false`]
 
@@ -61,7 +61,11 @@ There are a variety of constructors for `Response`, which set sane defaults for 
 
 ### Headers
 
-`Headers` is a type alias for `Dict{String,String}`.
+`Headers` is an `Associative{String,String}`. You can interact with it
+much like a Dict, but it can have multiple keys with the same
+value. For example `Set-Cookie` may be set multiple time for multiple
+cookies.
+
 There is a default constructor, `headers`, to produce a reasonable default set of headers.
 The defaults are as follows:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,8 +33,34 @@ facts("HttpCommon utility functions") do
         @fact parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") =>
             ["foo" => "<a href='foo'>bar</a>run&++", "bar" => "123"]
     end
-
 end
 
 # Check doesn't throw
 RFC1123_datetime()
+
+facts("Headers") do
+    context("Headers with duplicates") do
+        h = Headers()
+        @fact length(h) => 0
+
+        h["Content-Type"] = "text/html"
+        @fact length(h) => 1
+
+        h["Set-Cookie"] = "user=me;"
+        @fact length(h) => 2
+
+        h["Set-Cookie"] = "pass=secret;"
+        @fact length(h) => 3
+
+        @fact h["Content-Type"] => "text/html"
+        @fact headersforkey(h, "Set-Cookie") => ["user=me;", "pass=secret;"]
+        @fact h |> collect |> sort => [("Content-Type", "text/html"),
+                                       ("Set-Cookie", "pass=secret;"),
+                                       ("Set-Cookie", "user=me;")]
+
+        delete!(h, "Set-Cookie")
+        @fact length(h) => 1
+        @fact h["Content-Type"] => "text/html"
+        @fact get(h, "Set-Cookie", "**DEFAULT**") => "**DEFAULT**"
+    end
+end


### PR DESCRIPTION
Unfortunately, HTTP can have duplicate headers, namely 'Set-Cookie'.
We could just store headers as Dict{String,Vector{String}}, but
that would push the pain onto everybody, where few are going to care.

By creating a 'Headers' type which impliments 'Associative' the users
can interact with headers as simply as if it were a
Dict{String,String}, but it's still safe for duplicate headers.