### PR TITLE
Add `@compat` in some places

### DIFF
--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -159,17 +159,17 @@ headers() = Dict{String,String}([
 @compat typealias HttpData Union(Vector{UInt8}, String)
 asbytes(r::ByteString) = r.data
 asbytes(r::String) = asbytes(bytestring(r))
-asbytes(r) = convert(Vector{UInt8}, r)
+asbytes(r) = @compat convert(Vector{UInt8}, r)
 
 
 type Request
     method::String
     resource::String
     headers::Headers
-    data::Vector{UInt8}
+    data::@compat(Vector{UInt8})
     uri::URI
 end
-Request() = Request("", "", Dict{String,String}(), Vector{UInt8}(), URI(""))
+Request() = Request("", "", Dict{String,String}(), @compat(Vector{UInt8}()), URI(""))
 Request(method, resource, headers, data) = Request(method, resource, headers, data, URI(""))
 
 function show(io::IO, r::Request)
@@ -211,7 +211,7 @@ type Response
     status::Int
     headers::Headers
     cookies::Cookies
-    data::Vector{UInt8}
+    data::@compat(Vector{UInt8})
     finished::Bool
     # The history of requests that generated the response. Can be greater than
     # one if a redirect was involved.


### PR DESCRIPTION
While trying to use Escher I found some errors that said that some types couldn't be constructed. I tracked down the issue and found that there were some `@compat`'s missing here.