### PR TITLE
Rewrite the whole package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - release
     - nightly
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
     - julia -e 'Pkg.clone(pwd())'
     - julia -e 'Pkg.test("HttpCommon", coverage=true)'
 after_success:
-    - julia -e 'cd(Pkg.dir("HttpCommon")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+    - julia -e 'cd(Pkg.dir("HttpCommon")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Zach Allaun, Daniel Espeset, Leah Hanson, and other contributors.
+Copyright (c) 2014 JuliaWeb contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 This package provides types and helper functions for dealing with the HTTP protocol in Julia:
 
-* types to represent `Request`s, `Response`s, and `Headers`
+* Types to represent `Headers`, `Request`s, `Cookie`s, and `Response`s
 * a dictionary of `STATUS_CODES`
     (maps integer codes to string descriptions; covers all the codes from the RFCs)
 * a function to `escapeHTML` in a `String`
@@ -31,7 +31,7 @@ Dict( "Server"           => "Julia/$VERSION",
 ```
 
 
-#### Request
+#### `Request`
 
 A `Request` represents an HTTP request sent by a client to a server.
 It has five fields:
@@ -42,31 +42,28 @@ It has five fields:
 * `data`: the data in the request as a vector of bytes
 
 
-### Response
+#### `Cookie`
+
+A `Cookie` represents an HTTP cookie. It has three fields:
+`name` and `value` are strings, and `attrs` is dictionary
+of pairs of strings.
+
+
+#### Response
 
 A `Response` represents an HTTP response sent to a client by a server.
+It has six fields:
 
-```julia
-type Response
-    status::Int
-    headers::Headers
-    data::HttpData
-    finished::Bool
-end
-```
+* `status`: HTTP status code (see `STATUS_CODES`) [default: `200`]
+* `headers`: `Headers` [default: `HttpCommmon.headers()`]
+* `cookies`: Dictionary of strings => `Cookie`s
+* `data`: the request data as a vector of bytes [default: `UInt8[]`]
+* `finished`: `true` if the `Reponse` is valid, meaning that it can be
+  converted to an actual HTTP response [default: `false`]
+* `requests`: the history of requests that generated the response.
+  Can be greater than one if a redirect was involved.
 
-* `status` is the HTTP status code (see `STATUS_CODES`) [default: `200`]
-* `headers` is the `Dict` of headers [default: `headers()`, see Headers below]
-* `data` is the response data (as a `String` or `Array{Uint8}`) [default: `""`]
-* `finished` is `true` if the `Reponse` is valid, meaning that it can be converted to an actual HTTP response [default: `false`]
-
-There are a variety of constructors for `Response`, which set sane defaults for unspecified values.
-
-```julia
-Response([statuscode::Int])
-Response(statuscode::Int,[h::Headers],[d::HttpData])
-Response(d::HttpData,[h::Headers])
-```
+Response has many constructors - use `methods(Response)` for full list.
 
 
 #### STATUS_CODES

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This package provides types and helper functions for dealing with the HTTP proto
 * types to represent `Request`s, `Response`s, and `Headers`
 * a dictionary of `STATUS_CODES`
     (maps integer codes to string descriptions; covers all the codes from the RFCs)
-* a bitmask representation of HTTP request methods
 * a function to `escapeHTML` in a `String`
 * a function to turn a query string from a url into a `Dict{String,String}`
 
@@ -89,15 +88,6 @@ STATUS_CODES[404] #=> "Not Found"
 STATUS_CODES[418] #=> "I'm a teapot"
 STATUS_CODES[500] #=> "Internal Server Error"
 ```
-    
-### HttpMethodBitmasks
-
-HttpCommon provides `Int` bitmasks to represent the HTTP request methods
-(GET, POST, PUT, UPDATE, DELETE, OPTIONS, HEAD).
-There are two dictionaries, `HttpMethodNameToBitmask` and `HttpMethodBitmaskToName`, to allow for mapping back and forth from `String` names to `Int` bitmasks.
-
-The purpose of having bitmasks is that you can write `GET | POST | UPDATE` and end up with a bitmask representing the union of those HTTP methods.
-
 
 #### `escapeHTML(i::String)`
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ It has six fields:
 Response has many constructors - use `methods(Response)` for full list.
 
 
+## Constants
+
 #### STATUS_CODES
 
-`STATUS_CODES` is a `const` `Dict{Int,String}`.
-It maps all the status codes defined in RFC's to their descriptions.
+`STATUS_CODES` is a dictionary (`Int => String`) that maps all the
+status codes defined in RFC's to their descriptions, e.g.
 
 ```julia
 STATUS_CODES[200] #=> "OK"
@@ -77,6 +79,9 @@ STATUS_CODES[404] #=> "Not Found"
 STATUS_CODES[418] #=> "I'm a teapot"
 STATUS_CODES[500] #=> "Internal Server Error"
 ```
+
+
+## Utility functions
 
 #### `escapeHTML(i::String)`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This package provides types and helper functions for dealing with the HTTP proto
     (maps integer codes to string descriptions; covers all the codes from the RFCs)
 * a bitmask representation of HTTP request methods
 * a function to `escapeHTML` in a `String`
-* a pair of functions to `encodeURI` and `decodeURI`
 * a function to turn a query string from a url into a `Dict{String,String}`
 
 
@@ -102,16 +101,6 @@ The purpose of having bitmasks is that you can write `GET | POST | UPDATE` and e
 ### `escapeHTML(i::String)`
 
 `escapeHTML` will return a new `String` with the following characters escaped: `&`, `<`, `>`, `"`.
-
-### `encodeURI(decoded::String)`
-
-`encodeURI` returns a new, URI-safe string.
-It escapes all non-URI characters (only letters, digits, `-`, `_` , `.`, and `~` are allowed) in the standard way.
-
-### `decodeURI(encoded::String)`
-
-`decodeURI` returns a new `String` with all the unsafe characters returned to their original meanings.
-It works with the output of `encodeURI` as well as other standard URI encoders.
 
 
 #### `parsequerystring(query::String)`

--- a/README.md
+++ b/README.md
@@ -74,17 +74,10 @@ The defaults are as follows:
 [ "Server" => "Julia/$VERSION",
   "Content-Type" => "text/html; charset=utf-8",
   "Content-Language" => "en",
-  "Date" => RFC1123_datetime()]
+  "Date" => Dates.format(now(Dates.UTC),Dates.RFC1123Format)]
 ```
 
-The last setting, `"Date"` uses another HttpCommon function:
-
-```julia
-RFC1123_datetime([CalendarTime])
-```
-    
-When an argument is not provided, the current time (`now()`) is used.
-RFC1123 describes the correct format for putting timestamps into HTTP headers.
+Where the last setting, `"Date"` uses RFC1123 formatting for dates in HTTP headers.
 
 ### STATUS_CODES
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ There are two dictionaries, `HttpMethodNameToBitmask` and `HttpMethodBitmaskToNa
 
 The purpose of having bitmasks is that you can write `GET | POST | UPDATE` and end up with a bitmask representing the union of those HTTP methods.
 
-### `escapeHTML(i::String)`
 
-`escapeHTML` will return a new `String` with the following characters escaped: `&`, `<`, `>`, `"`.
+#### `escapeHTML(i::String)`
+
+Returns a string with special HTML characters escaped: `&, <, >, ", '`
 
 
 #### `parsequerystring(query::String)`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HttpCommon.jl
 
 [![Build Status](https://travis-ci.org/JuliaWeb/HttpCommon.jl.svg?branch=master)](https://travis-ci.org/JuliaWeb/HttpCommon.jl)
-[![Coverage Status](https://coveralls.io/repos/JuliaWeb/HttpCommon.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaWeb/HttpCommon.jl?branch=master)
+[![codecov.io](http://codecov.io/github/JuliaWeb/HttpCommon.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaWeb/HttpCommon.jl?branch=master)
 
 [![HttpCommon](http://pkg.julialang.org/badges/HttpCommon_0.3.svg)](http://pkg.julialang.org/?pkg=HttpCommon&ver=0.3)
 [![HttpCommon](http://pkg.julialang.org/badges/HttpCommon_0.4.svg)](http://pkg.julialang.org/?pkg=HttpCommon&ver=0.4)

--- a/README.md
+++ b/README.md
@@ -113,20 +113,22 @@ It escapes all non-URI characters (only letters, digits, `-`, `_` , `.`, and `~`
 `decodeURI` returns a new `String` with all the unsafe characters returned to their original meanings.
 It works with the output of `encodeURI` as well as other standard URI encoders.
 
-### `parsequerystring(query::String)`
 
-`parsequerystring` takes a query string (as from a URL) and returns a `Dict{String,String}` representing the same data.
+#### `parsequerystring(query::String)`
 
-An example:
+Convert a valid querystring to a Dict:
 
 ```julia
 q = "foo=bar&baz=%3Ca%20href%3D%27http%3A%2F%2Fwww.hackershool.com%27%3Ehello%20world%21%3C%2Fa%3E"
 parsequerystring(q)
-# => ["foo"=>"bar","baz"=>"<a href='http://www.hackershool.com'>hello world!</a>"]
+# Dict{ASCIIString,ASCIIString} with 2 entries:
+#   "baz" => "<a href='http://www.hackershool.com'>hello world!</a>"
+#   "foo" => "bar"
 ```
 
 
 ---
+
 
 ~~~~
 :::::::::::::

--- a/README.md
+++ b/README.md
@@ -31,23 +31,16 @@ Dict( "Server"           => "Julia/$VERSION",
 ```
 
 
-### Request
+#### Request
 
-A `Request` represents an HTTP request sent by a client to a server. 
+A `Request` represents an HTTP request sent by a client to a server.
+It has five fields:
 
-```julia    
-type Request
-    method::String
-    resource::String
-    headers::Headers
-    data::String
-end
-```
+* `method`: an HTTP methods string (e.g. "GET")
+* `resource`: the resource requested (e.g. "/hello/world")
+* `headers`: see `Headers` above
+* `data`: the data in the request as a vector of bytes
 
-* `method` is an HTTP methods string ("GET", "PUT", etc)
-* `resource` is the url resource requested ("/hello/world")
-* `headers` is a `Dict` of field name `String`s to value `String`s
-* `data` is the data in the request
 
 ### Response
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,20 @@ This package provides types and helper functions for dealing with the HTTP proto
 * a function to turn a query string from a url into a `Dict{String,String}`
 
 
-## Documentation
+## HTTP Types
+
+#### `Headers`
+
+`Headers` represents the header fields for an HTTP request, and is type alias for `Dict{String,String}`.
+There is a default constructor, `headers`, that produces a reasonable default set of headers:
+```julia
+Dict( "Server"           => "Julia/$VERSION",
+      "Content-Type"     => "text/html; charset=utf-8",
+      "Content-Language" => "en",
+      "Date"             => Dates.format(now(Dates.UTC), Dates.RFC1123Format) )
+```
+
+
 ### Request
 
 A `Request` represents an HTTP request sent by a client to a server. 
@@ -62,22 +75,8 @@ Response(statuscode::Int,[h::Headers],[d::HttpData])
 Response(d::HttpData,[h::Headers])
 ```
 
-### Headers
 
-`Headers` is a type alias for `Dict{String,String}`.
-There is a default constructor, `headers`, to produce a reasonable default set of headers.
-The defaults are as follows:
-
-```julia
-[ "Server" => "Julia/$VERSION",
-  "Content-Type" => "text/html; charset=utf-8",
-  "Content-Language" => "en",
-  "Date" => Dates.format(now(Dates.UTC),Dates.RFC1123Format)]
-```
-
-Where the last setting, `"Date"` uses RFC1123 formatting for dates in HTTP headers.
-
-### STATUS_CODES
+#### STATUS_CODES
 
 `STATUS_CODES` is a `const` `Dict{Int,String}`.
 It maps all the status codes defined in RFC's to their descriptions.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,2 @@
 julia 0.4-
-Dates
-Compat
 URIParser

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -4,18 +4,7 @@ module HttpCommon
 
 import URIParser: URI, unescape
 
-export GET,
-       POST,
-       PUT,
-       UPDATE,
-       DELETE,
-       OPTIONS,
-       HEAD,
-       HttpMethodBitmask,
-       HttpMethodBitmasks,
-       HttpMethodNameToBitmask,
-       HttpMethodBitmaskToName,
-       Headers,
+export Headers,
        Request,
        Response,
        escapeHTML,
@@ -28,31 +17,6 @@ include("mimetypes.jl")
 # All HTTP status codes, as a Dict of code => description
 export STATUS_CODES
 include("status.jl")
-
-# HTTP method bitmasks and indexes, allow for fancy GET | POST | UPDATE style APIs.
-typealias HttpMethodBitmask Int
-
-const HttpMethodBitmasks = HttpMethodBitmask[
-    (const GET     = 2^0),
-    (const POST    = 2^1),
-    (const PUT     = 2^2),
-    (const UPDATE  = 2^3),
-    (const DELETE  = 2^4),
-    (const OPTIONS = 2^5),
-    (const HEAD    = 2^6)
-]
-
-const HttpMethodNameToBitmask = Dict{String, HttpMethodBitmask}([
-    ("GET"     , GET),
-    ("POST"    , POST),
-    ("PUT"     , PUT),
-    ("UPDATE"  , UPDATE),
-    ("DELETE"  , DELETE),
-    ("OPTIONS" , OPTIONS),
-    ("HEAD"    , HEAD)
-])
-
-const HttpMethodBitmaskToName = (HttpMethodBitmask => String)[v => k for (k, v) in HttpMethodNameToBitmask]
 
 
 # HTTP Headers

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -12,7 +12,6 @@ export STATUS_CODES,
        DELETE,
        OPTIONS,
        HEAD,
-       RFC1123_datetime,
        HttpMethodBitmask,
        HttpMethodBitmasks,
        HttpMethodNameToBitmask,
@@ -115,17 +114,6 @@ const HttpMethodNameToBitmask = Dict{String, HttpMethodBitmask}([
 
 const HttpMethodBitmaskToName = (HttpMethodBitmask => String)[v => k for (k, v) in HttpMethodNameToBitmask]
 
-# Get RFC 1123 datetimes
-#
-#     RFC1123_datetime( now() ) => "Wed, 27 Mar 2013 08:26:04 GMT"
-#     RFC1123_datetime()        => "Wed, 27 Mar 2013 08:26:04 GMT"
-#
-RFC1123_datetime(t::DateTime) = begin
-    Dates.format(t, Dates.RFC1123Format) * " GMT"
-end
-RFC1123_datetime() = RFC1123_datetime(Dates.now(Dates.UTC))
-
-
 
 # HTTP Headers
 #
@@ -137,7 +125,7 @@ headers() = Dict{String,String}([
     ("Server"            , "Julia/$VERSION"),
     ("Content-Type"      , "text/html; charset=utf-8"),
     ("Content-Language"  , "en"),
-    ("Date"              , RFC1123_datetime())
+    ("Date"              , Dates.format(now(Dates.UTC),Dates.RFC1123Format))
 ])
 
 # HTTP request

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -28,36 +28,29 @@ headers() = Headers(
     "Date"              => Dates.format(now(Dates.UTC), Dates.RFC1123Format) )
 
 
-# HTTP request
-#
-# - method   => valid HTTP method string (e.g. "GET")
-# - resource => requested resource (e.g. "/hello/world")
-# - headers  => HTTP headers
-# - data     => request data
-# - state    => used to store various data during request processing
+"""
+A `Request` represents an HTTP request sent by a client to a server.
+It has five fields:
 
-typealias HttpData Union{Vector{UInt8}, String}
-asbytes(r::ByteString) = r.data
-asbytes(r::String) = asbytes(bytestring(r))
-asbytes(r) = convert(Vector{UInt8}, r)
-
-
+* `method`: an HTTP methods string (e.g. "GET")
+* `resource`: the resource requested (e.g. "/hello/world")
+* `headers`: see `Headers` above
+* `data`: the data in the request as a vector of bytes
+"""
 type Request
-    method::String
-    resource::String
+    method::UTF8String      # HTTP method string (e.g. "GET")
+    resource::UTF8String    # Resource requested (e.g. "/hello/world")
     headers::Headers
     data::Vector{UInt8}
     uri::URI
 end
-Request() = Request("", "", Dict{String,String}(), UInt8[], URI(""))
+Request() = Request("", "", Headers(), UInt8[], URI(""))
 Request(method, resource, headers, data) = Request(method, resource, headers, data, URI(""))
 
-function Base.show(io::IO, r::Request)
-    print(io, "Request(")
-    print(io, r.uri)
-    print(io, ", ", length(r.headers), " Headers")
-    print(io, ", ", sizeof(r.data), " Bytes in Body)")
-end
+Base.show(io::IO, r::Request) = print(io, "Request(", r.uri, ", ",
+                                        length(r.headers), " headers, ",
+                                        sizeof(r.data), " bytes in body)")
+
 
 # HTTP response
 #
@@ -86,6 +79,11 @@ end
 Cookie(name, value) = Cookie(name, value, Dict{UTF8String, UTF8String}())
 
 typealias Cookies Dict{UTF8String, Cookie}
+
+typealias HttpData Union{Vector{UInt8}, String}
+asbytes(r::ByteString) = r.data
+asbytes(r::String) = asbytes(bytestring(r))
+asbytes(r) = convert(Vector{UInt8}, r)
 
 type Response
     status::Int

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -272,25 +272,28 @@ function encodeURI(decoded::String)
     encoded
 end
 
-# parsequerystring
-#
-# Convert a valid querystring to a Dict:
-#
-#    q = "foo=bar&baz=%3Ca%20href%3D%27http%3A%2F%2Fwww.hackershool.com%27%3Ehello%20world%21%3C%2Fa%3E"
-#    parsequerystring(q)
-#    # => Dict("foo"=>"bar","baz"=>"<a href='http://www.hackershool.com'>hello world!</a>")
-#
-function parsequerystring(query::String)
-    q = Dict{String,String}()
-    if !('=' in query)
-        return throw("Not a valid query string: $query, must contain at least one key=value pair.")
-    end
-    for set in split(query, "&")
-        key, val = split(set, "=")
-        q[decodeURI(key)] = decodeURI(val)
+
+"""
+parsequerystring(query::String)
+
+Convert a valid querystring to a Dict:
+
+    q = "foo=bar&baz=%3Ca%20href%3D%27http%3A%2F%2Fwww.hackershool.com%27%3Ehello%20world%21%3C%2Fa%3E"
+    parsequerystring(q)
+    # Dict{ASCIIString,ASCIIString} with 2 entries:
+    #   "baz" => "<a href='http://www.hackershool.com'>hello world!</a>"
+    #   "foo" => "bar"
+"""
+function parsequerystring{T<:String}(query::T)
+    q = Dict{T,T}()
+    length(query) == 0 && return q
+    for field in split(query, "&")
+        keyval = split(field, "=")
+        length(keyval) != 2 && throw(ArgumentError("Field '$field' did not contain an '='."))
+        q[decodeURI(keyval[1])] = decodeURI(keyval[2])
     end
     q
 end
 
 
-end # module Httplib
+end # module HttpCommon

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -2,8 +2,7 @@ __precompile__()
 
 module HttpCommon
 
-using URIParser
-import URIParser: unescape
+import URIParser: URI, unescape
 
 export STATUS_CODES,
        GET,
@@ -26,8 +25,6 @@ export STATUS_CODES,
        mimetypes
 
 include("mimetypes.jl")
-
-import Base: show, ==
 
 const STATUS_CODES = Dict([
     (100, "Continue"),
@@ -151,7 +148,7 @@ end
 Request() = Request("", "", Dict{String,String}(), UInt8[], URI(""))
 Request(method, resource, headers, data) = Request(method, resource, headers, data, URI(""))
 
-function show(io::IO, r::Request)
+function Base.show(io::IO, r::Request)
     print(io, "Request(")
     print(io, r.uri)
     print(io, ", ", length(r.headers), " Headers")
@@ -207,7 +204,7 @@ Response()                                = Response(200)
 
 
 
-show(io::IO,r::Response) = print(io,"Response(",r.status," ",STATUS_CODES[r.status],", ",length(r.headers)," Headers, ",sizeof(r.data)," Bytes in Body)")
+Base.show(io::IO,r::Response) = print(io,"Response(",r.status," ",STATUS_CODES[r.status],", ",length(r.headers)," Headers, ",sizeof(r.data)," Bytes in Body)")
 
 function FileResponse(filename)
     if isfile(filename)
@@ -220,15 +217,20 @@ function FileResponse(filename)
     end
 end
 
-# Escape HTML characters
-#
-# Safety first!
-#
+
+"""
+escapeHTML(i::String)
+
+Returns a string with special HTML characters escaped: &, <, >, ", '
+"""
 function escapeHTML(i::String)
-    o = replace(i, r"&(?!(\w+|\#\d+);)", "&amp;")
+    # Refer to http://stackoverflow.com/a/7382028/3822752 for spec. links
+    o = replace(i, "&", "&amp;")
+    o = replace(o, "\"", "&quot;")
+    o = replace(o, "'", "&#39;")
     o = replace(o, "<", "&lt;")
     o = replace(o, ">", "&gt;")
-    replace(o, "\"", "&quot;")
+    return o
 end
 
 

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -19,18 +19,14 @@ export STATUS_CODES
 include("status.jl")
 
 
-# HTTP Headers
-#
-# Dict Type for HTTP headers
-# `headers()` for building default Response Headers
-#
+# `Headers` represents the header fields for an HTTP request.
 typealias Headers Dict{String,String}
-headers() = Dict{String,String}([
-    ("Server"            , "Julia/$VERSION"),
-    ("Content-Type"      , "text/html; charset=utf-8"),
-    ("Content-Language"  , "en"),
-    ("Date"              , Dates.format(now(Dates.UTC),Dates.RFC1123Format))
-])
+headers() = Headers(
+    "Server"            => "Julia/$VERSION",
+    "Content-Type"      => "text/html; charset=utf-8",
+    "Content-Language"  => "en",
+    "Date"              => Dates.format(now(Dates.UTC), Dates.RFC1123Format) )
+
 
 # HTTP request
 #

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -4,8 +4,7 @@ module HttpCommon
 
 import URIParser: URI, unescape
 
-export STATUS_CODES,
-       GET,
+export GET,
        POST,
        PUT,
        UPDATE,
@@ -21,69 +20,14 @@ export STATUS_CODES,
        Response,
        escapeHTML,
        parsequerystring,
-       FileResponse,
-       mimetypes
+       FileResponse
 
+export mimetypes
 include("mimetypes.jl")
 
-const STATUS_CODES = Dict([
-    (100, "Continue"),
-    (101, "Switching Protocols"),
-    (102, "Processing"),                          # RFC 2518, obsoleted by RFC 4918
-    (200, "OK"),
-    (201, "Created"),
-    (202, "Accepted"),
-    (203, "Non-Authoritative Information"),
-    (204, "No Content"),
-    (205, "Reset Content"),
-    (206, "Partial Content"),
-    (207, "Multi-Status"),                        # RFC 4918
-    (300, "Multiple Choices"),
-    (301, "Moved Permanently"),
-    (302, "Moved Temporarily"),
-    (303, "See Other"),
-    (304, "Not Modified"),
-    (305, "Use Proxy"),
-    (307, "Temporary Redirect"),
-    (400, "Bad Request"),
-    (401, "Unauthorized"),
-    (402, "Payment Required"),
-    (403, "Forbidden"),
-    (404, "Not Found"),
-    (405, "Method Not Allowed"),
-    (406, "Not Acceptable"),
-    (407, "Proxy Authentication Required"),
-    (408, "Request Time-out"),
-    (409, "Conflict"),
-    (410, "Gone"),
-    (411, "Length Required"),
-    (412, "Precondition Failed"),
-    (413, "Request Entity Too Large"),
-    (414, "Request-URI Too Large"),
-    (415, "Unsupported Media Type"),
-    (416, "Requested Range Not Satisfiable"),
-    (417, "Expectation Failed"),
-    (418, "I'm a teapot"),                        # RFC 2324
-    (422, "Unprocessable Entity"),                # RFC 4918
-    (423, "Locked"),                              # RFC 4918
-    (424, "Failed Dependency"),                   # RFC 4918
-    (425, "Unordered Collection"),                # RFC 4918
-    (426, "Upgrade Required"),                    # RFC 2817
-    (428, "Precondition Required"),               # RFC 6585
-    (429, "Too Many Requests"),                   # RFC 6585
-    (431, "Request Header Fields Too Large"),     # RFC 6585
-    (500, "Internal Server Error"),
-    (501, "Not Implemented"),
-    (502, "Bad Gateway"),
-    (503, "Service Unavailable"),
-    (504, "Gateway Time-out"),
-    (505, "HTTP Version Not Supported"),
-    (506, "Variant Also Negotiates"),             # RFC 2295
-    (507, "Insufficient Storage"),                # RFC 4918
-    (509, "Bandwidth Limit Exceeded"),
-    (510, "Not Extended"),                        # RFC 2774
-    (511, "Network Authentication Required")      # RFC 6585
-])
+# All HTTP status codes, as a Dict of code => description
+export STATUS_CODES
+include("status.jl")
 
 # HTTP method bitmasks and indexes, allow for fancy GET | POST | UPDATE style APIs.
 typealias HttpMethodBitmask Int

--- a/src/status.jl
+++ b/src/status.jl
@@ -1,0 +1,59 @@
+# All HTTP status codes, as a Dict of code => description
+const STATUS_CODES = Dict([
+    (100, "Continue"),
+    (101, "Switching Protocols"),
+    (102, "Processing"),                          # RFC 2518, obsoleted by RFC 4918
+    (200, "OK"),
+    (201, "Created"),
+    (202, "Accepted"),
+    (203, "Non-Authoritative Information"),
+    (204, "No Content"),
+    (205, "Reset Content"),
+    (206, "Partial Content"),
+    (207, "Multi-Status"),                        # RFC 4918
+    (300, "Multiple Choices"),
+    (301, "Moved Permanently"),
+    (302, "Moved Temporarily"),
+    (303, "See Other"),
+    (304, "Not Modified"),
+    (305, "Use Proxy"),
+    (307, "Temporary Redirect"),
+    (400, "Bad Request"),
+    (401, "Unauthorized"),
+    (402, "Payment Required"),
+    (403, "Forbidden"),
+    (404, "Not Found"),
+    (405, "Method Not Allowed"),
+    (406, "Not Acceptable"),
+    (407, "Proxy Authentication Required"),
+    (408, "Request Time-out"),
+    (409, "Conflict"),
+    (410, "Gone"),
+    (411, "Length Required"),
+    (412, "Precondition Failed"),
+    (413, "Request Entity Too Large"),
+    (414, "Request-URI Too Large"),
+    (415, "Unsupported Media Type"),
+    (416, "Requested Range Not Satisfiable"),
+    (417, "Expectation Failed"),
+    (418, "I'm a teapot"),                        # RFC 2324
+    (422, "Unprocessable Entity"),                # RFC 4918
+    (423, "Locked"),                              # RFC 4918
+    (424, "Failed Dependency"),                   # RFC 4918
+    (425, "Unordered Collection"),                # RFC 4918
+    (426, "Upgrade Required"),                    # RFC 2817
+    (428, "Precondition Required"),               # RFC 6585
+    (429, "Too Many Requests"),                   # RFC 6585
+    (431, "Request Header Fields Too Large"),     # RFC 6585
+    (500, "Internal Server Error"),
+    (501, "Not Implemented"),
+    (502, "Bad Gateway"),
+    (503, "Service Unavailable"),
+    (504, "Gateway Time-out"),
+    (505, "HTTP Version Not Supported"),
+    (506, "Variant Also Negotiates"),             # RFC 2295
+    (507, "Insufficient Storage"),                # RFC 4918
+    (509, "Bandwidth Limit Exceeded"),
+    (510, "Not Extended"),                        # RFC 2774
+    (511, "Network Authentication Required")      # RFC 6585
+])

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-FactCheck

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,38 +1,31 @@
-if VERSION < v"0.4-"
-    using Dates
-else
-    using Base.Dates
-end
-
-using Compat
-using FactCheck
 using HttpCommon
+using FactCheck
 
 facts("HttpCommon utility functions") do
 
     context("RFC1123 compliant datetimes") do
-        @fact RFC1123_datetime(DateTime(2013, 5, 2, 13, 45, 7)) =>
+        @fact RFC1123_datetime(DateTime(2013, 5, 2, 13, 45, 7)) -->
             "Thu, 02 May 2013 13:45:07 GMT"
     end
 
     context("Escape HTML") do
-        @fact escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") =>
+        @fact escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") -->
             "&lt;script type='text/javascript'&gt;alert('sucker');&lt;/script&gt; foo bar"
     end
 
     context("Decode URI") do
-        @fact decodeURI("%3Ca+href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B") =>
+        @fact decodeURI("%3Ca+href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B") -->
             "<a href='foo'>bar</a>run&++"
     end
 
     context("Encode URI") do
-        @fact encodeURI("<a href='foo'>bar</a>run&++") =>
+        @fact encodeURI("<a href='foo'>bar</a>run&++") -->
             "%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B"
     end
 
     context("Parse URL query strings") do
-        @fact parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") =>
-        @compat Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")
+        @fact parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") -->
+            Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,11 @@ using Base.Test
 # Headers
 @test isa(HttpCommon.headers(), Headers)
 
+# Request
+@test sprint(show, Request()) == "Request(:/, 0 headers, 0 bytes in body)"
+@test sprint(show, Request("GET", "/get", HttpCommon.headers(), "")) ==
+        "Request(:/, 4 headers, 0 bytes in body)"
+
 # Escape HTML
 @test escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") ==
         "&lt;script type=&#39;text/javascript&#39;&gt;alert(&#39;sucker&#39;);&lt;/script&gt; foo bar"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using HttpCommon
 using Base.Test
 
+# Headers
+@test isa(HttpCommon.headers(), Headers)
+
 # Escape HTML
 @test escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") ==
         "&lt;script type=&#39;text/javascript&#39;&gt;alert(&#39;sucker&#39;);&lt;/script&gt; foo bar"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,29 +1,18 @@
 using HttpCommon
-using FactCheck
+using Base.Test
 
-facts("HttpCommon utility functions") do
+# Escape HTML
+@test escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") ==
+        "&lt;script type='text/javascript'&gt;alert('sucker');&lt;/script&gt; foo bar"
 
-    context("Escape HTML") do
-        @fact escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") -->
-            "&lt;script type='text/javascript'&gt;alert('sucker');&lt;/script&gt; foo bar"
-    end
+# Decode URI
+@test decodeURI("%3Ca+href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B") ==
+        "<a href='foo'>bar</a>run&++"
 
-    context("Decode URI") do
-        @fact decodeURI("%3Ca+href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B") -->
-            "<a href='foo'>bar</a>run&++"
-    end
+# Encode URI
+@test encodeURI("<a href='foo'>bar</a>run&++") ==
+        "%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B"
 
-    context("Encode URI") do
-        @fact encodeURI("<a href='foo'>bar</a>run&++") -->
-            "%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B"
-    end
-
-    context("Parse URL query strings") do
-        @fact parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") -->
-            Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")
-    end
-
-end
-
-# Throw error if any tests fails
-FactCheck.exitstatus()
+# Parse URL query strings
+@test parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") ==
+        Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,3 +16,6 @@ using Base.Test
 # Parse URL query strings
 @test parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") ==
         Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")
+@test parsequerystring("") == Dict()
+@test_throws ArgumentError parsequerystring("looknopairs")
+@test_throws ArgumentError parsequerystring("good=pair&badpair")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,14 +5,6 @@ using Base.Test
 @test escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") ==
         "&lt;script type='text/javascript'&gt;alert('sucker');&lt;/script&gt; foo bar"
 
-# Decode URI
-@test decodeURI("%3Ca+href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B") ==
-        "<a href='foo'>bar</a>run&++"
-
-# Encode URI
-@test encodeURI("<a href='foo'>bar</a>run&++") ==
-        "%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B"
-
 # Parse URL query strings
 @test parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") ==
         Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 # Escape HTML
 @test escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") ==
-        "&lt;script type='text/javascript'&gt;alert('sucker');&lt;/script&gt; foo bar"
+        "&lt;script type=&#39;text/javascript&#39;&gt;alert(&#39;sucker&#39;);&lt;/script&gt; foo bar"
 
 # Parse URL query strings
 @test parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,42 @@
 using HttpCommon
 using Base.Test
 
-# Headers
+# headers
 @test isa(HttpCommon.headers(), Headers)
 
 # Request
 @test sprint(show, Request()) == "Request(:/, 0 headers, 0 bytes in body)"
 @test sprint(show, Request("GET", "/get", HttpCommon.headers(), "")) ==
         "Request(:/, 4 headers, 0 bytes in body)"
+
+# Cookie
+@test sprint(show, Cookie("test","it")) ==
+        "Cookie(test, it, 0 attributes)"
+        
+# Response
+h = HttpCommon.headers()
+@test sprint(show, Response(200, h, "HttpCommon")) ==
+        "Response(200 OK, 4 headers, 10 bytes in body)"
+@test sprint(show, Response(200, h, UInt8[1,2,3])) ==
+        "Response(200 OK, 4 headers, 3 bytes in body)"
+@test sprint(show, Response(200, h)) ==
+        "Response(200 OK, 4 headers, 0 bytes in body)"
+@test sprint(show, Response(200, "HttpCommon")) ==
+        "Response(200 OK, 4 headers, 10 bytes in body)"
+@test sprint(show, Response(200, UInt8[1,2,3])) ==
+        "Response(200 OK, 4 headers, 3 bytes in body)"
+@test sprint(show, Response("HttpCommon", h)) ==
+        "Response(200 OK, 4 headers, 10 bytes in body)"
+@test sprint(show, Response(UInt8[1,2,3], h)) ==
+        "Response(200 OK, 4 headers, 3 bytes in body)"
+@test sprint(show, Response("HttpCommon")) ==
+        "Response(200 OK, 4 headers, 10 bytes in body)"
+@test sprint(show, Response(UInt8[1,2,3])) ==
+        "Response(200 OK, 4 headers, 3 bytes in body)"
+@test sprint(show, Response(200)) ==
+        "Response(200 OK, 4 headers, 0 bytes in body)"
+@test sprint(show, Response()) ==
+        "Response(200 OK, 4 headers, 0 bytes in body)"
 
 # Escape HTML
 @test escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,6 @@ using FactCheck
 
 facts("HttpCommon utility functions") do
 
-    context("RFC1123 compliant datetimes") do
-        @fact RFC1123_datetime(DateTime(2013, 5, 2, 13, 45, 7)) -->
-            "Thu, 02 May 2013 13:45:07 GMT"
-    end
-
     context("Escape HTML") do
         @fact escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") -->
             "&lt;script type='text/javascript'&gt;alert('sucker');&lt;/script&gt; foo bar"
@@ -29,9 +24,6 @@ facts("HttpCommon utility functions") do
     end
 
 end
-
-# Check doesn't throw
-RFC1123_datetime()
 
 # Throw error if any tests fails
 FactCheck.exitstatus()


### PR DESCRIPTION
Only API change was removing the `URI` functions, which duplicated `URIParser`. Complete coverage and docs, except `FileResponse`