### PR TITLE
Fixed an issue with incompatible String subtyping.

### DIFF
--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -130,7 +130,7 @@ Convert a valid querystring to a Dict:
     #   "foo" => "bar"
 """
 function parsequerystring{T<:String}(query::T)
-    q = Dict{T,T}()
+    q = Dict{String,String}()
     length(query) == 0 && return q
     for field in split(query, "&")
         keyval = split(field, "=")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Base.Test
 # Cookie
 @test sprint(show, Cookie("test","it")) ==
         "Cookie(test, it, 0 attributes)"
-        
+
 # Response
 h = HttpCommon.headers()
 @test sprint(show, Response(200, h, "HttpCommon")) ==
@@ -45,6 +45,11 @@ h = HttpCommon.headers()
 # Parse URL query strings
 @test parsequerystring("foo=%3Ca%20href%3D%27foo%27%3Ebar%3C%2Fa%3Erun%26%2B%2B&bar=123") ==
         Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")
+
+begin
+  substrings = split(UTF8String("a%20=1&b=%202,b,c"), ",")
+  @test parsequerystring(substrings[1]) == Dict("a " => "1", "b" => " 2")
+end
 @test parsequerystring("") == Dict()
 @test_throws ArgumentError parsequerystring("looknopairs")
 @test_throws ArgumentError parsequerystring("good=pair&badpair")


### PR DESCRIPTION
The `unescape(str)` function in `URIParser.jl` calls `replace` from Julia Base, which can change the type of a string:

```julia
julia> replace(UTF8String("hi"), "h", " ")
" i"

julia> typeof(ans)
ASCIIString
```

Calling `parsequerystring{T <: UTF8String}` would fail to build the Dict, 
as `ASCIIString <: UTF8String == false`

Changing the type on the return Dict to `String` fixes this.