### PR TITLE
Adding in server response codes. Handling unknown codes.

### DIFF
--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -105,7 +105,7 @@ Response(s::Int)                          = Response(s, headers(), UInt8[])
 Response()                                = Response(200)
 
 function Base.show(io::IO, r::Response)
-    print(io, "Response(", r.status, " ", STATUS_CODES[r.status], ", ",
+    print(io, "Response(", r.status, " ", get(STATUS_CODES, r.status, "Unknown Code"), ", ",
           length(r.headers)," headers, ",
           sizeof(r.data)," bytes in body)")
 end

--- a/src/status.jl
+++ b/src/status.jl
@@ -56,5 +56,13 @@ const STATUS_CODES = Dict([
     (509, "Bandwidth Limit Exceeded"),
     (510, "Not Extended"),                        # RFC 2774
     (511, "Network Authentication Required"),     # RFC 6585
-    (524, "Connection Timeout from CloudFlare")
+    (520, "CloudFlare Server Error: Unknown"),
+    (521, "CloudFlare Server Error: Connection Refused"),
+    (522, "CloudFlare Server Error: Connection Timeout"),
+    (523, "CloudFlare Server Error: Origin Server Unreachable"),
+    (524, "CloudFlare Server Error: Connection Timeout"),
+    (525, "CloudFlare Server Error: Connection Failed"),
+    (526, "CloudFlare Server Error: Invalid SSL Ceritificate"),
+    (527, "CloudFlare Server Error: Railgun Error")
+
 ])

--- a/src/status.jl
+++ b/src/status.jl
@@ -55,5 +55,6 @@ const STATUS_CODES = Dict([
     (507, "Insufficient Storage"),                # RFC 4918
     (509, "Bandwidth Limit Exceeded"),
     (510, "Not Extended"),                        # RFC 2774
-    (511, "Network Authentication Required")      # RFC 6585
+    (511, "Network Authentication Required"),     # RFC 6585
+    (524, "Connection Timeout from CloudFlare")
 ])

--- a/src/status.jl
+++ b/src/status.jl
@@ -45,6 +45,12 @@ const STATUS_CODES = Dict([
     (428, "Precondition Required"),               # RFC 6585
     (429, "Too Many Requests"),                   # RFC 6585
     (431, "Request Header Fields Too Large"),     # RFC 6585
+    (440, "Login Timeout"),
+    (444, "nginx error: No Response"),
+    (495, "nginx error: SSL Certificate Error"),
+    (496, "nginx error: SSL Certificate Required"),
+    (497, "nginx error: HTTP -> HTTPS"),
+    (499, "nginx error or Antivirus intercepted request or ArcGIS error"),
     (500, "Internal Server Error"),
     (501, "Not Implemented"),
     (502, "Bad Gateway"),
@@ -63,6 +69,6 @@ const STATUS_CODES = Dict([
     (524, "CloudFlare Server Error: Connection Timeout"),
     (525, "CloudFlare Server Error: Connection Failed"),
     (526, "CloudFlare Server Error: Invalid SSL Ceritificate"),
-    (527, "CloudFlare Server Error: Railgun Error")
-
+    (527, "CloudFlare Server Error: Railgun Error"),
+    (530, "Site Frozen")
 ])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,8 @@ h = HttpCommon.headers()
         "Response(200 OK, 4 headers, 0 bytes in body)"
 @test sprint(show, Response()) ==
         "Response(200 OK, 4 headers, 0 bytes in body)"
+@test sprint(show, Response(999)) ==
+        "Response(999 Unknown Code, 4 headers, 0 bytes in body)"
 
 # Escape HTML
 @test escapeHTML("<script type='text/javascript'>alert('sucker');</script> foo bar") ==


### PR DESCRIPTION
No message for 524 response so a key error message appears rather than a server error message. Added in entry for a 524 response to prevent this. 