### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ os:
     - linux
     - osx
 julia:
-  - 0.4
-  - 0.5
-  - nightly
+    - 0.5
+    - 0.6
+    - nightly
 notifications:
     email: false
 sudo: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.4
+julia 0.5
 URIParser
-Compat 0.7.20

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -2,8 +2,6 @@ __precompile__()
 
 module HttpCommon
 
-using Compat
-using Compat: UTF8String
 using URIParser: URI, unescape
 
 export Headers, Request, Cookie, Response, escapeHTML, parsequerystring
@@ -17,7 +15,7 @@ include("status.jl")
 """
 `Headers` represents the header fields for an HTTP request.
 """
-const Headers = Dict{AbstractString,AbstractString}
+const Headers = Dict{AbstractString, AbstractString}
 headers() = Headers(
     "Server"            => "Julia/$VERSION",
     "Content-Type"      => "text/html; charset=utf-8",
@@ -35,8 +33,8 @@ It has five fields:
 * `data`: the request data as a vector of bytes
 """
 type Request
-    method::UTF8String      # HTTP method string (e.g. "GET")
-    resource::UTF8String    # Resource requested (e.g. "/hello/world")
+    method::String      # HTTP method string (e.g. "GET")
+    resource::String    # Resource requested (e.g. "/hello/world")
     headers::Headers
     data::Vector{UInt8}
     uri::URI
@@ -55,11 +53,11 @@ A `Cookie` represents an HTTP cookie. It has three fields:
 of pairs of strings.
 """
 type Cookie
-    name::UTF8String
-    value::UTF8String
-    attrs::Dict{UTF8String, UTF8String}
+    name::String
+    value::String
+    attrs::Dict{String, String}
 end
-Cookie(name, value) = Cookie(name, value, Dict{UTF8String, UTF8String}())
+Cookie(name, value) = Cookie(name, value, Dict{String, String}())
 Base.show(io::IO, c::Cookie) = print(io, "Cookie(", c.name, ", ", c.value,
                                         ", ", length(c.attrs), " attributes)")
 
@@ -82,7 +80,7 @@ Response has many constructors - use `methods(Response)` for full list.
 type Response
     status::Int
     headers::Headers
-    cookies::Dict{UTF8String, Cookie}
+    cookies::Dict{String, Cookie}
     data::Vector{UInt8}
     request::Nullable{Request}
     history::Vector{Response}
@@ -95,7 +93,7 @@ end
 # `finished` will default to `false`.
 const HttpData = Union{Vector{UInt8}, AbstractString}
 Response(s::Int, h::Headers, d::HttpData) =
-  Response(s, h, Dict{UTF8String, Cookie}(), d, Nullable(), Response[], false, Request[])
+  Response(s, h, Dict{String, Cookie}(), d, Nullable(), Response[], false, Request[])
 Response(s::Int, h::Headers)              = Response(s, h, UInt8[])
 Response(s::Int, d::HttpData)             = Response(s, headers(), d)
 Response(d::HttpData, h::Headers)         = Response(200, h, d)
@@ -133,7 +131,7 @@ Convert a valid querystring to a Dict:
 
     q = "foo=bar&baz=%3Ca%20href%3D%27http%3A%2F%2Fwww.hackershool.com%27%3Ehello%20world%21%3C%2Fa%3E"
     parsequerystring(q)
-    # Dict{ASCIIString,ASCIIString} with 2 entries:
+    # Dict{String,String} with 2 entries:
     #   "baz" => "<a href='http://www.hackershool.com'>hello world!</a>"
     #   "foo" => "bar"
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using HttpCommon
 using Base.Test
-using Compat
-import Compat: UTF8String
+
 # headers
 @test isa(HttpCommon.headers(), Headers)
 
@@ -50,7 +49,7 @@ h = HttpCommon.headers()
         Dict("foo" => "<a href='foo'>bar</a>run&++", "bar" => "123")
 
 begin
-  substrings = split(UTF8String("a%20=1&b=%202,b,c"), ",")
+  substrings = split("a%20=1&b=%202,b,c", ",")
   @test parsequerystring(substrings[1]) == Dict("a " => "1", "b" => " 2")
 end
 @test parsequerystring("") == Dict()


### PR DESCRIPTION
Remove `UTF8String`s and bump to minimum requirement of Julia 0.5.

Avoids significant deprecation spam:
```
WARNING: Compat.UTF8String is deprecated, use String instead.
... repeats around 50 times! ...
```