### PR TITLE
Prepare for 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd())'
+    - julia -e 'Pkg.add("URIParser");using URIParser'
     - julia -e 'Pkg.test("HttpCommon", coverage=true)'
 after_success:
     - julia -e 'cd(Pkg.dir("HttpCommon")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd())'
-    - julia -e 'Pkg.add("URIParser");using URIParser'
     - julia -e 'Pkg.test("HttpCommon", coverage=true)'
 after_success:
     - julia -e 'cd(Pkg.dir("HttpCommon")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It has five fields:
 * `resource`: the resource requested (e.g. "/hello/world")
 * `headers`: see `Headers` above
 * `data`: the data in the request as a vector of bytes
+* `uri`: additional details, normally not used
 
 
 #### `Cookie`

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 URIParser
+Compat 0.37.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
+julia 0.6
 URIParser

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -1,5 +1,5 @@
 __precompile__()
-
+ 
 module HttpCommon
 
 using URIParser: URI, unescape
@@ -15,13 +15,12 @@ include("status.jl")
 """
 `Headers` represents the header fields for an HTTP request.
 """
-const Headers = Dict{AbstractString, AbstractString}
+const Headers = Dict{String, String}
 headers() = Headers(
     "Server"            => "Julia/$VERSION",
     "Content-Type"      => "text/html; charset=utf-8",
     "Content-Language"  => "en",
     "Date"              => Dates.format(now(Dates.UTC), Dates.RFC1123Format) )
-
 
 """
 A `Request` represents an HTTP request sent by a client to a server.
@@ -32,7 +31,7 @@ It has five fields:
 * `headers`: see `Headers` above
 * `data`: the request data as a vector of bytes
 """
-type Request
+mutable struct Request
     method::String      # HTTP method string (e.g. "GET")
     resource::String    # Resource requested (e.g. "/hello/world")
     headers::Headers
@@ -40,7 +39,8 @@ type Request
     uri::URI
 end
 Request() = Request("", "", Headers(), UInt8[], URI(""))
-Request(method, resource, headers, data) = Request(method, resource, headers, data, URI(""))
+Request(method, resource, headers, data) = 
+          Request(String(method), String(resource), Headers(headers), Vector{UInt8}(data), URI(""))
 
 Base.show(io::IO, r::Request) = print(io, "Request(", r.uri, ", ",
                                         length(r.headers), " headers, ",
@@ -52,12 +52,12 @@ A `Cookie` represents an HTTP cookie. It has three fields:
 `name` and `value` are strings, and `attrs` is dictionary
 of pairs of strings.
 """
-type Cookie
+mutable struct Cookie
     name::String
     value::String
     attrs::Dict{String, String}
 end
-Cookie(name, value) = Cookie(name, value, Dict{String, String}())
+Cookie(name, value) = Cookie(String(name), String(value), Dict{String, String}())
 Base.show(io::IO, c::Cookie) = print(io, "Cookie(", c.name, ", ", c.value,
                                         ", ", length(c.attrs), " attributes)")
 
@@ -77,7 +77,7 @@ It has six fields:
 
 Response has many constructors - use `methods(Response)` for full list.
 """
-type Response
+mutable struct Response
     status::Int
     headers::Headers
     cookies::Dict{String, Cookie}
@@ -91,15 +91,20 @@ type Response
 end
 # If a Response is instantiated with all of fields except for `finished`,
 # `finished` will default to `false`.
-const HttpData = Union{Vector{UInt8}, AbstractString}
+const HttpData = Union{Vector{UInt8}, String}
 Response(s::Int, h::Headers, d::HttpData) =
-  Response(s, h, Dict{String, Cookie}(), d, Nullable(), Response[], false, Request[])
+  Response(s, h, Dict{String, Cookie}(), Vector{UInt8}(d), Nullable(), Response[], false, Request[])
+Response(s::Int, h::Dict{AbstractString,AbstractString}, d::HttpData) =
+  Response(s, Headers(h), Dict{String, Cookie}(), Vector{UInt8}(d), Nullable(), Response[], false, Request[])
 Response(s::Int, h::Headers)              = Response(s, h, UInt8[])
-Response(s::Int, d::HttpData)             = Response(s, headers(), d)
-Response(d::HttpData, h::Headers)         = Response(200, h, d)
-Response(d::HttpData)                     = Response(d, headers())
+Response(s::Int, h::Dict{AbstractString,AbstractString}) = Response(s, Headers(h), UInt8[])
+Response(s::Int, d::HttpData)             = Response(s, headers(), Vector{UInt8}(d))
+Response(d::HttpData, h::Headers)         = Response(200, h, Vector{UInt8}(d))
+Response(d::HttpData, h::Dict{AbstractString,AbstractString})         = Response(200, Headers(h), Vector{UInt8}(d))
+Response(d::HttpData)                     = Response(Vector{UInt8}(d), headers())
 Response(s::Int)                          = Response(s, headers(), UInt8[])
 Response()                                = Response(200)
+
 
 function Base.show(io::IO, r::Response)
     print(io, "Response(", r.status, " ", get(STATUS_CODES, r.status, "Unknown Code"), ", ",
@@ -109,23 +114,23 @@ end
 
 
 """
-escapeHTML(i::AbstractString)
+escapeHTML(i::String)
 
 Returns a string with special HTML characters escaped: &, <, >, ", '
 """
-function escapeHTML(i::AbstractString)
+function escapeHTML(i::String)
     # Refer to http://stackoverflow.com/a/7382028/3822752 for spec. links
     o = replace(i, "&", "&amp;")
     o = replace(o, "\"", "&quot;")
     o = replace(o, "'", "&#39;")
     o = replace(o, "<", "&lt;")
     o = replace(o, ">", "&gt;")
-    return o
+    return o 
 end
 
 
 """
-parsequerystring(query::AbstractString)
+parsequerystring(query::String)
 
 Convert a valid querystring to a Dict:
 
@@ -135,8 +140,8 @@ Convert a valid querystring to a Dict:
     #   "baz" => "<a href='http://www.hackershool.com'>hello world!</a>"
     #   "foo" => "bar"
 """
-function parsequerystring{T<:AbstractString}(query::T)
-    q = Dict{AbstractString,AbstractString}()
+function parsequerystring(query::T) where T<:AbstractString
+    q = Dict{String,String}()
     length(query) == 0 && return q
     for field in split(query, "&")
         keyval = split(field, "=")

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -1,7 +1,7 @@
 __precompile__()
  
 module HttpCommon
-using Base.Dates
+using Compat.Dates
 using URIParser: URI, unescape
 
 export Headers, Request, Cookie, Response, escapeHTML, parsequerystring

--- a/src/HttpCommon.jl
+++ b/src/HttpCommon.jl
@@ -1,7 +1,7 @@
 __precompile__()
  
 module HttpCommon
-
+using Base.Dates
 using URIParser: URI, unescape
 
 export Headers, Request, Cookie, Response, escapeHTML, parsequerystring
@@ -30,6 +30,7 @@ It has five fields:
 * `resource`: the resource requested (e.g. "/hello/world")
 * `headers`: see `Headers` above
 * `data`: the request data as a vector of bytes
+* `uri`: additional details, normally not used
 """
 mutable struct Request
     method::String      # HTTP method string (e.g. "GET")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,9 @@ using HttpCommon
 using Base.Test
 
 # headers
+h = HttpCommon.headers()
+@test isa(h, Headers)
 @test isa(HttpCommon.headers(), Headers)
-
 # Request
 @test sprint(show, Request()) == "Request(:/, 0 headers, 0 bytes in body)"
 @test sprint(show, Request("GET", "/get", HttpCommon.headers(), "")) ==
@@ -14,12 +15,18 @@ using Base.Test
         "Cookie(test, it, 0 attributes)"
 
 # Response
-h = HttpCommon.headers()
+h_abstract = Dict{AbstractString, AbstractString}(h)
 @test sprint(show, Response(200, h, "HttpCommon")) ==
+        "Response(200 OK, 4 headers, 10 bytes in body)"
+@test sprint(show, Response(200, h_abstract, "HttpCommon")) ==
         "Response(200 OK, 4 headers, 10 bytes in body)"
 @test sprint(show, Response(200, h, UInt8[1,2,3])) ==
         "Response(200 OK, 4 headers, 3 bytes in body)"
+@test sprint(show, Response(200, h_abstract, UInt8[1,2,3])) ==
+        "Response(200 OK, 4 headers, 3 bytes in body)"
 @test sprint(show, Response(200, h)) ==
+        "Response(200 OK, 4 headers, 0 bytes in body)"
+@test sprint(show, Response(200, h_abstract)) ==
         "Response(200 OK, 4 headers, 0 bytes in body)"
 @test sprint(show, Response(200, "HttpCommon")) ==
         "Response(200 OK, 4 headers, 10 bytes in body)"
@@ -27,7 +34,11 @@ h = HttpCommon.headers()
         "Response(200 OK, 4 headers, 3 bytes in body)"
 @test sprint(show, Response("HttpCommon", h)) ==
         "Response(200 OK, 4 headers, 10 bytes in body)"
+@test sprint(show, Response("HttpCommon", h_abstract)) ==
+        "Response(200 OK, 4 headers, 10 bytes in body)"
 @test sprint(show, Response(UInt8[1,2,3], h)) ==
+        "Response(200 OK, 4 headers, 3 bytes in body)"
+@test sprint(show, Response(UInt8[1,2,3], h_abstract)) ==
         "Response(200 OK, 4 headers, 3 bytes in body)"
 @test sprint(show, Response("HttpCommon")) ==
         "Response(200 OK, 4 headers, 10 bytes in body)"


### PR DESCRIPTION
Dropped supporting 0.5.
There's still a depwarn in 0.7 for 'using Base.Test'.

```
mod:   .travis.yml                 Drop 0.5
mod:   README.md                   Comment, issue #43 URI field
mod:   REQUIRE                     Drop 0.5
mod:   src/HttpCommon.jl           AbstractString -> String. Constructors accepting AbstractString.
```
